### PR TITLE
Turn off ssh-agent inside gnome-keyring-daemon could be confusing

### DIFF
--- a/YubiKey.rst
+++ b/YubiKey.rst
@@ -40,7 +40,7 @@ Configure GNOME-Shell to use gpg-agent and disable ssh-agent
 
 Turn off ssh-agent inside gnome-keyring-daemon.
 
-For Fedora this can be achieved by creating a new file /etc/X11/xinit/Xclients.d/Xclients.gnome-session.sh or appending to the existing. Add the following code portion::
+For Fedora this can be achieved by creating a new file /etc/X11/xinit/Xclients.d/Xclients.gnome-session.sh or appending to the existing one. Add the following code portion::
 
   if [[ $(gconftool-2 --get /apps/gnome-keyring/daemon-components/ssh) != "false" ]]; then
     gconftool-2 --type bool --set /apps/gnome-keyring/daemon-components/ssh false

--- a/YubiKey.rst
+++ b/YubiKey.rst
@@ -38,7 +38,9 @@ If you have a dev key, Reboot your YubiKey (remove and reinsert) so that ykneomg
 Configure GNOME-Shell to use gpg-agent and disable ssh-agent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Turn off ssh-agent inside gnome-keyring-daemon::
+Turn off ssh-agent inside gnome-keyring-daemon.
+
+For Fedora this can be achieved by creating a new file /etc/X11/xinit/Xclients.d/Xclients.gnome-session.sh or appending to the existing. Add the following code portion::
 
   if [[ $(gconftool-2 --get /apps/gnome-keyring/daemon-components/ssh) != "false" ]]; then
     gconftool-2 --type bool --set /apps/gnome-keyring/daemon-components/ssh false
@@ -105,6 +107,9 @@ Reload GNOME-Shell So that the gpg-agent stuff above takes effect.
 ------------------
 
 Rebooting the machine works the best.
+After reboot, make sure that the output of the following command is false::
+
+  gconftool-2 --get /apps/gnome-keyring/daemon-components/ssh
 
 
 Get gpshell etc to fix serial number*


### PR DESCRIPTION
I followed up the procedure and the part "Turn off ssh-agent inside gnome-keyring-daemon" is not very straigth-forward. Determinig which file need to be modified with suggested snipet gave me a hard time.

I have verified it works and it is reproducible

I wish this could help